### PR TITLE
Pull Request: Fiscal Shocks Extension to Tax DSGE Model

### DIFF
--- a/Codes/plot_irfs_and_multipliers_b.m
+++ b/Codes/plot_irfs_and_multipliers_b.m
@@ -1,0 +1,885 @@
+%% plot_irfs_and_multipliers_b.m
+%% =========================================================================
+%% Generate IRF plots and multiplier tables
+%% Replicates presentation style of Mertens & Ravn (2013) and Zubairy (2014)
+%% 
+%% VERSION B: For model with 6 TAX SHOCKS (no government spending shock)
+%%   - tau_c (consumption tax)
+%%   - tau_l (labor income tax)
+%%   - tau_k (capital income tax)
+%%   - tau_i (interest income tax)
+%%   - tau_d (dividend tax)
+%%   - tau_ic (investment tax credit)
+%%
+%% Run this AFTER running Dynare on tax_dsge_fiscal_shocks_b.mod
+%% =========================================================================
+
+close all;
+
+%% =========================================================================
+%% PART 1: SETUP AND DATA EXTRACTION
+%% =========================================================================
+
+% Check if Dynare results exist
+if ~exist('oo_', 'var')
+    error('Dynare results not found. Run dynare tax_dsge_fiscal_shocks_b first.');
+end
+
+fprintf('\n');
+fprintf('================================================================\n');
+fprintf('  FISCAL MULTIPLIER ANALYSIS - Post-Processing Script (Option B)\n');
+fprintf('================================================================\n');
+fprintf('\n');
+
+% Define horizon
+T = 40;  % quarters
+quarters = 0:T-1;
+
+% Horizons for multiplier table (matching Zubairy 2014)
+horizons = [1, 4, 12, 20];
+n_horizons = length(horizons);
+
+%% =========================================================================
+%% PART 2: EXTRACT STEADY STATE VALUES
+%% =========================================================================
+
+fprintf('Extracting steady-state values...\n');
+
+% Function to get steady state value by variable name
+get_ss = @(varname) oo_.steady_state(strmatch(varname, M_.endo_names, 'exact'));
+
+% Get steady state values
+y_ss = get_ss('y');
+c_ss = get_ss('c');
+i_ss = get_ss('i');
+g_ss = get_ss('g');
+l_ss = get_ss('l');
+w_ss = get_ss('w');
+r_k_ss = get_ss('r_k');
+k_ss = get_ss('k');
+d_ss = get_ss('d');
+b_ss = get_ss('b');
+r_ss = get_ss('r');
+
+% Additional steady state values needed for tax revenue computations
+p_ss = get_ss('p');
+v_ss = get_ss('v');
+k_tau_ss = get_ss('k_tau');
+
+% Get steady-state tax rates
+tau_c_ss = get_ss('tau_c');
+tau_l_ss = get_ss('tau_l');
+tau_k_ss = get_ss('tau_k');
+tau_i_ss = get_ss('tau_i');
+tau_d_ss = get_ss('tau_d');
+tau_ic_ss = get_ss('tau_ic');
+
+% Get discount factor
+beta = M_.params(strmatch('betta', M_.param_names, 'exact'));
+delta_tau = M_.params(strmatch('delta_tau', M_.param_names, 'exact'));
+e_tau     = M_.params(strmatch('e_tau', M_.param_names, 'exact'));
+
+R = 1/beta - 1;  % Discount rate for present value calculations
+
+fprintf('  GDP (y_ss) = %.4f\n', y_ss);
+fprintf('  Consumption (c_ss) = %.4f\n', c_ss);
+fprintf('  Investment (i_ss) = %.4f\n', i_ss);
+fprintf('  Gov spending (g_ss) = %.4f\n', g_ss);
+fprintf('  Discount rate (R) = %.4f\n', R);
+fprintf('\n');
+
+%% =========================================================================
+%% PART 3: CALCULATE TAX REVENUE BASES (for normalization)
+%% =========================================================================
+
+fprintf('Calculating tax revenue bases for normalization...\n');
+
+% Tax revenue bases (steady state)
+% These are used to convert tax rate changes to revenue changes
+T_c_base  = c_ss;                                               % Consumption tax base
+T_l_base  = (w_ss * l_ss) / p_ss;                                 % Labor income tax base (real wage bill)
+T_k_base  = (r_k_ss * v_ss * k_ss) / p_ss - (delta_tau * k_tau_ss) - (e_tau * i_ss); % Capital income tax base (net of allowances)
+T_i_base  = (r_ss * b_ss) / p_ss;                                 % Interest income tax base (real interest income)
+T_d_base  = d_ss / p_ss;                                          % Dividend tax base (real dividends)
+T_ic_base = i_ss;                                                 % ITC base (investment)
+
+% Steady-state fiscal flows
+Rev_c_ss   = tau_c_ss  * T_c_base;
+Rev_l_ss   = tau_l_ss  * T_l_base;
+Rev_k_ss   = tau_k_ss  * T_k_base;
+Rev_i_ss   = tau_i_ss  * T_i_base;
+Rev_d_ss   = tau_d_ss  * T_d_base;
+Spend_ic_ss = tau_ic_ss * T_ic_base;                               % ITC subsidy outlay
+fprintf('  Consumption tax revenue = %.4f (%.1f%% of GDP)\n', Rev_c_ss, 100*Rev_c_ss/y_ss);
+fprintf('  Labor tax revenue = %.4f (%.1f%% of GDP)\n', Rev_l_ss, 100*Rev_l_ss/y_ss);
+fprintf('  Capital tax revenue = %.4f (%.1f%% of GDP)\n', Rev_k_ss, 100*Rev_k_ss/y_ss);
+fprintf('  Interest tax revenue = %.4f (%.1f%% of GDP)\n', Rev_i_ss, 100*Rev_i_ss/y_ss);
+fprintf('  Dividend tax revenue = %.4f (%.1f%% of GDP)\n', Rev_d_ss, 100*Rev_d_ss/y_ss);
+fprintf('  ITC subsidy outlay = %.4f (%.1f%% of GDP)\n', Spend_ic_ss, 100*Spend_ic_ss/y_ss);
+fprintf('\n');
+
+%% =========================================================================
+%% PART 4: EXTRACT ALL IRFs
+%% =========================================================================
+
+fprintf('Extracting impulse response functions...\n');
+
+% --- Consumption Tax Shock ---
+irf_y_tc = oo_.irfs.y_e_tau_c;
+irf_c_tc = oo_.irfs.c_e_tau_c;
+irf_i_tc = oo_.irfs.i_e_tau_c;
+irf_l_tc = oo_.irfs.l_e_tau_c;
+irf_tc_tc = oo_.irfs.tau_c_e_tau_c;
+irf_p_tc = oo_.irfs.p_e_tau_c;
+irf_w_tc = oo_.irfs.w_e_tau_c;
+irf_r_tc = oo_.irfs.r_e_tau_c;
+irf_rk_tc = oo_.irfs.r_k_e_tau_c;
+irf_v_tc = oo_.irfs.v_e_tau_c;
+irf_k_tc = oo_.irfs.k_e_tau_c;
+irf_ktau_tc = oo_.irfs.k_tau_e_tau_c;
+irf_b_tc = oo_.irfs.b_e_tau_c;
+irf_d_tc = oo_.irfs.d_e_tau_c;
+irf_rev_c_tc = oo_.irfs.rev_c_e_tau_c;
+irf_rev_c_tc = oo_.irfs.rev_c_e_tau_c;
+irf_rev_l_tc = oo_.irfs.rev_l_e_tau_c;
+irf_rev_k_tc = oo_.irfs.rev_k_e_tau_c;
+irf_rev_i_tc = oo_.irfs.rev_i_e_tau_c;
+irf_rev_d_tc = oo_.irfs.rev_d_e_tau_c;
+irf_rev_total_tc = irf_rev_c_tc + irf_rev_l_tc + irf_rev_k_tc + irf_rev_i_tc + irf_rev_d_tc;
+
+
+
+% --- Labor Tax Shock ---
+irf_y_tl = oo_.irfs.y_e_tau_l;
+irf_c_tl = oo_.irfs.c_e_tau_l;
+irf_i_tl = oo_.irfs.i_e_tau_l;
+irf_l_tl = oo_.irfs.l_e_tau_l;
+irf_tl_tl = oo_.irfs.tau_l_e_tau_l;
+irf_p_tl = oo_.irfs.p_e_tau_l;
+irf_w_tl = oo_.irfs.w_e_tau_l;
+irf_r_tl = oo_.irfs.r_e_tau_l;
+irf_rk_tl = oo_.irfs.r_k_e_tau_l;
+irf_v_tl = oo_.irfs.v_e_tau_l;
+irf_k_tl = oo_.irfs.k_e_tau_l;
+irf_ktau_tl = oo_.irfs.k_tau_e_tau_l;
+irf_b_tl = oo_.irfs.b_e_tau_l;
+irf_d_tl = oo_.irfs.d_e_tau_l;
+irf_rev_l_tl = oo_.irfs.rev_l_e_tau_l;
+irf_rev_c_tl = oo_.irfs.rev_c_e_tau_l;
+irf_rev_l_tl = oo_.irfs.rev_l_e_tau_l;
+irf_rev_k_tl = oo_.irfs.rev_k_e_tau_l;
+irf_rev_i_tl = oo_.irfs.rev_i_e_tau_l;
+irf_rev_d_tl = oo_.irfs.rev_d_e_tau_l;
+irf_rev_total_tl = irf_rev_c_tl + irf_rev_l_tl + irf_rev_k_tl + irf_rev_i_tl + irf_rev_d_tl;
+
+
+
+% --- Capital Tax Shock ---
+irf_y_tk = oo_.irfs.y_e_tau_k;
+irf_c_tk = oo_.irfs.c_e_tau_k;
+irf_i_tk = oo_.irfs.i_e_tau_k;
+irf_l_tk = oo_.irfs.l_e_tau_k;
+irf_tk_tk = oo_.irfs.tau_k_e_tau_k;
+irf_p_tk = oo_.irfs.p_e_tau_k;
+irf_w_tk = oo_.irfs.w_e_tau_k;
+irf_r_tk = oo_.irfs.r_e_tau_k;
+irf_rk_tk = oo_.irfs.r_k_e_tau_k;
+irf_v_tk = oo_.irfs.v_e_tau_k;
+irf_k_tk = oo_.irfs.k_e_tau_k;
+irf_ktau_tk = oo_.irfs.k_tau_e_tau_k;
+irf_b_tk = oo_.irfs.b_e_tau_k;
+irf_d_tk = oo_.irfs.d_e_tau_k;
+irf_rev_k_tk = oo_.irfs.rev_k_e_tau_k;
+irf_rev_c_tk = oo_.irfs.rev_c_e_tau_k;
+irf_rev_l_tk = oo_.irfs.rev_l_e_tau_k;
+irf_rev_k_tk = oo_.irfs.rev_k_e_tau_k;
+irf_rev_i_tk = oo_.irfs.rev_i_e_tau_k;
+irf_rev_d_tk = oo_.irfs.rev_d_e_tau_k;
+irf_rev_total_tk = irf_rev_c_tk + irf_rev_l_tk + irf_rev_k_tk + irf_rev_i_tk + irf_rev_d_tk;
+
+
+
+% --- Interest Tax Shock ---
+irf_y_ti = oo_.irfs.y_e_tau_i;
+irf_c_ti = oo_.irfs.c_e_tau_i;
+irf_i_ti = oo_.irfs.i_e_tau_i;
+irf_l_ti = oo_.irfs.l_e_tau_i;
+irf_ti_ti = oo_.irfs.tau_i_e_tau_i;
+irf_p_ti = oo_.irfs.p_e_tau_i;
+irf_w_ti = oo_.irfs.w_e_tau_i;
+irf_r_ti = oo_.irfs.r_e_tau_i;
+irf_rk_ti = oo_.irfs.r_k_e_tau_i;
+irf_v_ti = oo_.irfs.v_e_tau_i;
+irf_k_ti = oo_.irfs.k_e_tau_i;
+irf_ktau_ti = oo_.irfs.k_tau_e_tau_i;
+irf_b_ti = oo_.irfs.b_e_tau_i;
+irf_d_ti = oo_.irfs.d_e_tau_i;
+irf_rev_i_ti = oo_.irfs.rev_i_e_tau_i;
+irf_rev_c_ti = oo_.irfs.rev_c_e_tau_i;
+irf_rev_l_ti = oo_.irfs.rev_l_e_tau_i;
+irf_rev_k_ti = oo_.irfs.rev_k_e_tau_i;
+irf_rev_i_ti = oo_.irfs.rev_i_e_tau_i;
+irf_rev_d_ti = oo_.irfs.rev_d_e_tau_i;
+irf_rev_total_ti = irf_rev_c_ti + irf_rev_l_ti + irf_rev_k_ti + irf_rev_i_ti + irf_rev_d_ti;
+
+
+
+% --- Dividend Tax Shock ---
+irf_y_td = oo_.irfs.y_e_tau_d;
+irf_c_td = oo_.irfs.c_e_tau_d;
+irf_i_td = oo_.irfs.i_e_tau_d;
+irf_l_td = oo_.irfs.l_e_tau_d;
+irf_td_td = oo_.irfs.tau_d_e_tau_d;
+irf_p_td = oo_.irfs.p_e_tau_d;
+irf_w_td = oo_.irfs.w_e_tau_d;
+irf_r_td = oo_.irfs.r_e_tau_d;
+irf_rk_td = oo_.irfs.r_k_e_tau_d;
+irf_v_td = oo_.irfs.v_e_tau_d;
+irf_k_td = oo_.irfs.k_e_tau_d;
+irf_ktau_td = oo_.irfs.k_tau_e_tau_d;
+irf_b_td = oo_.irfs.b_e_tau_d;
+irf_d_td = oo_.irfs.d_e_tau_d;
+irf_rev_d_td = oo_.irfs.rev_d_e_tau_d;
+irf_rev_c_td = oo_.irfs.rev_c_e_tau_d;
+irf_rev_l_td = oo_.irfs.rev_l_e_tau_d;
+irf_rev_k_td = oo_.irfs.rev_k_e_tau_d;
+irf_rev_i_td = oo_.irfs.rev_i_e_tau_d;
+irf_rev_d_td = oo_.irfs.rev_d_e_tau_d;
+irf_rev_total_td = irf_rev_c_td + irf_rev_l_td + irf_rev_k_td + irf_rev_i_td + irf_rev_d_td;
+
+
+
+% --- Investment Tax Credit Shock ---
+irf_y_tic = oo_.irfs.y_e_tau_ic;
+irf_c_tic = oo_.irfs.c_e_tau_ic;
+irf_i_tic = oo_.irfs.i_e_tau_ic;
+irf_l_tic = oo_.irfs.l_e_tau_ic;
+irf_tic_tic = oo_.irfs.tau_ic_e_tau_ic;
+irf_p_tic = oo_.irfs.p_e_tau_ic;
+irf_w_tic = oo_.irfs.w_e_tau_ic;
+irf_r_tic = oo_.irfs.r_e_tau_ic;
+irf_rk_tic = oo_.irfs.r_k_e_tau_ic;
+irf_v_tic = oo_.irfs.v_e_tau_ic;
+irf_k_tic = oo_.irfs.k_e_tau_ic;
+irf_ktau_tic = oo_.irfs.k_tau_e_tau_ic;
+irf_b_tic = oo_.irfs.b_e_tau_ic;
+irf_d_tic = oo_.irfs.d_e_tau_ic;
+irf_spend_ic_tic = oo_.irfs.spend_ic_e_tau_ic;
+irf_rev_c_tic = oo_.irfs.rev_c_e_tau_ic;
+irf_rev_l_tic = oo_.irfs.rev_l_e_tau_ic;
+irf_rev_k_tic = oo_.irfs.rev_k_e_tau_ic;
+irf_rev_i_tic = oo_.irfs.rev_i_e_tau_ic;
+irf_rev_d_tic = oo_.irfs.rev_d_e_tau_ic;
+irf_rev_total_tic = irf_rev_c_tic + irf_rev_l_tic + irf_rev_k_tic + irf_rev_i_tic + irf_rev_d_tic;
+irf_spend_ic_tic = oo_.irfs.spend_ic_e_tau_ic;
+
+
+
+fprintf('  Extracted IRFs for all 6 tax shocks.\n');
+%% =========================================================================
+%% PART 4B: NORMALIZE SHOCKS (Zubairy-style)
+%% =========================================================================
+% Tax shocks are normalized so that the implied impact change in total tax revenue
+% equals -1% of steady-state total tax revenue (tax cut convention).
+% The ITC shock is normalized so that the implied impact change in ITC outlays
+% equals +1% of steady-state GDP (since steady-state ITC outlays can be zero).
+
+Rev_total_ss = Rev_c_ss + Rev_l_ss + Rev_k_ss + Rev_i_ss + Rev_d_ss;
+target_tax_rev_drop = 0.01 * Rev_total_ss;
+target_itc_outlay   = 0.01 * y_ss;
+
+% Guard against zero impact responses
+if abs(irf_rev_total_tc(1)) < 1e-12, error('Impact total revenue response is zero for tau_c shock.'); end
+if abs(irf_rev_total_tl(1)) < 1e-12, error('Impact total revenue response is zero for tau_l shock.'); end
+if abs(irf_rev_total_tk(1)) < 1e-12, error('Impact total revenue response is zero for tau_k shock.'); end
+if abs(irf_rev_total_ti(1)) < 1e-12, error('Impact total revenue response is zero for tau_i shock.'); end
+if abs(irf_rev_total_td(1)) < 1e-12, error('Impact total revenue response is zero for tau_d shock.'); end
+if abs(irf_spend_ic_tic(1)) < 1e-12, error('Impact ITC outlay response is zero for tau_ic shock.'); end
+
+% Scaling factors for tax cuts: apply a negative sign so the normalized impulse is a cut
+scale_tc = target_tax_rev_drop / irf_rev_total_tc(1);
+scale_tl = target_tax_rev_drop / irf_rev_total_tl(1);
+scale_tk = target_tax_rev_drop / irf_rev_total_tk(1);
+scale_ti = target_tax_rev_drop / irf_rev_total_ti(1);
+scale_td = target_tax_rev_drop / irf_rev_total_td(1);
+
+% Scaling factor for ITC increase (outlay-based normalization)
+scale_tic = target_itc_outlay / irf_spend_ic_tic(1);
+
+% Normalized IRFs (already in the reporting direction: tax cuts and ITC increase)
+irf_y_tc_n = -scale_tc * irf_y_tc;
+irf_y_tl_n = -scale_tl * irf_y_tl;
+irf_y_tk_n = -scale_tk * irf_y_tk;
+irf_y_ti_n = -scale_ti * irf_y_ti;
+irf_y_td_n = -scale_td * irf_y_td;
+irf_y_tic_n =  scale_tic * irf_y_tic;
+
+irf_c_tc_n = -scale_tc * irf_c_tc;
+irf_c_tl_n = -scale_tl * irf_c_tl;
+irf_c_tk_n = -scale_tk * irf_c_tk;
+irf_c_ti_n = -scale_ti * irf_c_ti;
+irf_c_td_n = -scale_td * irf_c_td;
+irf_c_tic_n =  scale_tic * irf_c_tic;
+
+irf_i_tc_n = -scale_tc * irf_i_tc;
+irf_i_tl_n = -scale_tl * irf_i_tl;
+irf_i_tk_n = -scale_tk * irf_i_tk;
+irf_i_ti_n = -scale_ti * irf_i_ti;
+irf_i_td_n = -scale_td * irf_i_td;
+irf_i_tic_n =  scale_tic * irf_i_tic;
+
+irf_l_tc_n = -scale_tc * irf_l_tc;
+irf_l_tl_n = -scale_tl * irf_l_tl;
+irf_l_tk_n = -scale_tk * irf_l_tk;
+irf_l_ti_n = -scale_ti * irf_l_ti;
+irf_l_td_n = -scale_td * irf_l_td;
+irf_l_tic_n =  scale_tic * irf_l_tic;
+
+irf_rev_total_tc_n = -scale_tc * irf_rev_total_tc;
+irf_rev_total_tl_n = -scale_tl * irf_rev_total_tl;
+irf_rev_total_tk_n = -scale_tk * irf_rev_total_tk;
+irf_rev_total_ti_n = -scale_ti * irf_rev_total_ti;
+irf_rev_total_td_n = -scale_td * irf_rev_total_td;
+
+irf_spend_ic_tic_n = scale_tic * irf_spend_ic_tic;
+
+% Also normalize tax rate paths (useful for plots)
+irf_tc_tc_n = -scale_tc * irf_tc_tc;
+irf_tl_tl_n = -scale_tl * irf_tl_tl;
+irf_tk_tk_n = -scale_tk * irf_tk_tk;
+irf_ti_ti_n = -scale_ti * irf_ti_ti;
+irf_td_td_n = -scale_td * irf_td_td;
+irf_tic_tic_n = scale_tic * irf_tic_tic;
+
+fprintf('Normalization complete: tax cuts imply -1%% impact total tax revenue, ITC implies +1%% GDP impact outlay.\n\n');
+
+fprintf('\n');
+
+%% =========================================================================
+%% PART 4C: RAW IRFS FOR PLOTS (NO NORMALIZATION)
+%% =========================================================================
+% For plots, keep the original Dynare shock size.
+% Use the same sign convention as the multiplier reporting:
+%   - Tax shocks are shown as TAX CUTS (flip sign)
+%   - ITC shock is shown as an INCREASE in the credit (no sign flip)
+
+%% =========================================================================
+%% Plot scaling option
+%% If true, IRF plots use the normalized IRFs (same scaling used for multipliers).
+%% If false, IRF plots use raw Dynare IRFs (with sign flips for tax cuts only).
+SCALE_PLOTS_TO_NORMALIZATION = true;
+
+irf_y_tc_p   = -irf_y_tc;
+irf_y_tl_p   = -irf_y_tl;
+irf_y_tk_p   = -irf_y_tk;
+irf_y_ti_p   = -irf_y_ti;
+irf_y_td_p   = -irf_y_td;
+irf_y_tic_p  =  irf_y_tic;
+
+irf_c_tc_p   = -irf_c_tc;
+irf_c_tl_p   = -irf_c_tl;
+irf_c_tk_p   = -irf_c_tk;
+irf_c_ti_p   = -irf_c_ti;
+irf_c_td_p   = -irf_c_td;
+irf_c_tic_p  =  irf_c_tic;
+
+irf_i_tc_p   = -irf_i_tc;
+irf_i_tl_p   = -irf_i_tl;
+irf_i_tk_p   = -irf_i_tk;
+irf_i_ti_p   = -irf_i_ti;
+irf_i_td_p   = -irf_i_td;
+irf_i_tic_p  =  irf_i_tic;
+
+irf_l_tc_p   = -irf_l_tc;
+irf_l_tl_p   = -irf_l_tl;
+irf_l_tk_p   = -irf_l_tk;
+irf_l_ti_p   = -irf_l_ti;
+irf_l_td_p   = -irf_l_td;
+irf_l_tic_p  =  irf_l_tic;
+
+% Tax rate paths (percentage points), plotted as cuts for taxes
+irf_tc_tc_p  = -irf_tc_tc;
+irf_tl_tl_p  = -irf_tl_tl;
+irf_tk_tk_p  = -irf_tk_tk;
+irf_ti_ti_p  = -irf_ti_ti;
+irf_td_td_p  = -irf_td_td;
+irf_tic_tic_p = irf_tic_tic;
+
+if SCALE_PLOTS_TO_NORMALIZATION
+    irf_c_tc_p = irf_c_tc_n;
+    irf_c_td_p = irf_c_td_n;
+    irf_c_ti_p = irf_c_ti_n;
+    irf_c_tic_p = irf_c_tic_n;
+    irf_c_tk_p = irf_c_tk_n;
+    irf_c_tl_p = irf_c_tl_n;
+    irf_i_tc_p = irf_i_tc_n;
+    irf_i_td_p = irf_i_td_n;
+    irf_i_ti_p = irf_i_ti_n;
+    irf_i_tic_p = irf_i_tic_n;
+    irf_i_tk_p = irf_i_tk_n;
+    irf_i_tl_p = irf_i_tl_n;
+    irf_l_tc_p = irf_l_tc_n;
+    irf_l_td_p = irf_l_td_n;
+    irf_l_ti_p = irf_l_ti_n;
+    irf_l_tic_p = irf_l_tic_n;
+    irf_l_tk_p = irf_l_tk_n;
+    irf_l_tl_p = irf_l_tl_n;
+    irf_tc_tc_p = irf_tc_tc_n;
+    irf_td_td_p = irf_td_td_n;
+    irf_ti_ti_p = irf_ti_ti_n;
+    irf_tic_tic_p = irf_tic_tic_n;
+    irf_tk_tk_p = irf_tk_tk_n;
+    irf_tl_tl_p = irf_tl_tl_n;
+    irf_y_tc_p = irf_y_tc_n;
+    irf_y_td_p = irf_y_td_n;
+    irf_y_ti_p = irf_y_ti_n;
+    irf_y_tic_p = irf_y_tic_n;
+    irf_y_tk_p = irf_y_tk_n;
+    irf_y_tl_p = irf_y_tl_n;
+end
+
+
+%% =========================================================================
+%% PART 5: CALCULATE PRESENT VALUE MULTIPLIERS (Zubairy 2014 Style)
+%% =========================================================================
+% 
+% Multiplier Definition (Zubairy 2014, p. 184):
+%   PV Multiplier at horizon k = PV(DeltaY) / PV(DeltaF)
+%
+% where:
+%   PV(DeltaY) = sum_{j=0}^{k-1} (1+R)^{-j} * DeltaY_{t+j}
+%   PV(DeltaF) = sum_{j=0}^{k-1} (1+R)^{-j} * DeltaF_{t+j}
+%
+% For tax multipliers, DeltaF = change in tax REVENUE (not rate)
+%
+% NORMALIZATION: We express multipliers in terms of:
+%   "$ change in GDP per $ change in fiscal variable"
+%
+% This matches Zubairy's "1% of GDP" normalization.
+%% =========================================================================
+
+fprintf('Calculating present-value multipliers...\n');
+
+% Pre-allocate
+mult_tau_c = zeros(n_horizons, 1);
+mult_tau_l = zeros(n_horizons, 1);
+mult_tau_k = zeros(n_horizons, 1);
+mult_tau_i = zeros(n_horizons, 1);
+mult_tau_d = zeros(n_horizons, 1);
+mult_tau_ic = zeros(n_horizons, 1);
+
+for h = 1:n_horizons
+    k = horizons(h);
+    discount_factors = (1+R).^(-(0:k-1)');
+    
+    % =============================================================
+    % NOTE ON SIGN CONVENTIONS
+    % For tax rates (tau_c, tau_l, tau_k, tau_i, tau_d):
+    %   We report multipliers for TAX CUTS, so we flip the sign of all IRFs.
+    %   The denominator is the present value of the REVENUE DECREASE, so we use -PV(DeltaRevenue).
+    % For the investment tax credit (tau_ic):
+    %   We report multipliers for an INCREASE in the credit (a larger subsidy).
+    % =============================================================
+    
+    
+    % =============================================================
+    % Multipliers:
+    %   For tax shocks: PV(DeltaY) / PV(Delta total tax revenue), tax cut convention
+    %   For ITC: PV(DeltaY) / PV(Delta outlays), ITC increase convention
+    % =============================================================
+
+    % ===== CONSUMPTION TAX (CUT) =====
+    y_path = y_ss + irf_y_tc_n(1:k)';
+    rev_ss = Rev_total_ss;
+    rev_path = rev_ss + irf_rev_total_tc_n(1:k)';
+    dY = y_path - y_ss;
+    dRev = rev_path - rev_ss;
+    PV_Y = sum(discount_factors .* dY);
+    PV_Rev = sum(discount_factors .* dRev);
+    mult_tau_c(h) = PV_Y / (-PV_Rev);
+
+    % ===== LABOR INCOME TAX (CUT) =====
+    y_path = y_ss + irf_y_tl_n(1:k)';
+    rev_ss = Rev_total_ss;
+    rev_path = rev_ss + irf_rev_total_tl_n(1:k)';
+    dY = y_path - y_ss;
+    dRev = rev_path - rev_ss;
+    PV_Y = sum(discount_factors .* dY);
+    PV_Rev = sum(discount_factors .* dRev);
+    mult_tau_l(h) = PV_Y / (-PV_Rev);
+
+    % ===== CAPITAL INCOME TAX (CUT) =====
+    y_path = y_ss + irf_y_tk_n(1:k)';
+    rev_ss = Rev_total_ss;
+    rev_path = rev_ss + irf_rev_total_tk_n(1:k)';
+    dY = y_path - y_ss;
+    dRev = rev_path - rev_ss;
+    PV_Y = sum(discount_factors .* dY);
+    PV_Rev = sum(discount_factors .* dRev);
+    mult_tau_k(h) = PV_Y / (-PV_Rev);
+
+    % ===== INTEREST INCOME TAX (CUT) =====
+    y_path = y_ss + irf_y_ti_n(1:k)';
+    rev_ss = Rev_total_ss;
+    rev_path = rev_ss + irf_rev_total_ti_n(1:k)';
+    dY = y_path - y_ss;
+    dRev = rev_path - rev_ss;
+    PV_Y = sum(discount_factors .* dY);
+    PV_Rev = sum(discount_factors .* dRev);
+    mult_tau_i(h) = PV_Y / (-PV_Rev);
+
+    % ===== DIVIDEND TAX (CUT) =====
+    y_path = y_ss + irf_y_td_n(1:k)';
+    rev_ss = Rev_total_ss;
+    rev_path = rev_ss + irf_rev_total_td_n(1:k)';
+    dY = y_path - y_ss;
+    dRev = rev_path - rev_ss;
+    PV_Y = sum(discount_factors .* dY);
+    PV_Rev = sum(discount_factors .* dRev);
+    mult_tau_d(h) = PV_Y / (-PV_Rev);
+
+    % ===== INVESTMENT TAX CREDIT (INCREASE) =====
+    y_path = y_ss + irf_y_tic_n(1:k)';
+    spend_ss = Spend_ic_ss;
+    spend_path = spend_ss + irf_spend_ic_tic_n(1:k)';
+    dY = y_path - y_ss;
+    dSpend = spend_path - spend_ss;
+    PV_Y = sum(discount_factors .* dY);
+    PV_Spend = sum(discount_factors .* dSpend);
+    mult_tau_ic(h) = PV_Y / PV_Spend;
+end
+
+fprintf('  Multipliers calculated for horizons: ');
+fprintf('%d ', horizons);
+fprintf('quarters\n\n');
+
+%% =========================================================================
+%% PART 6: DISPLAY MULTIPLIER TABLE (Zubairy 2014 Style)
+%% =========================================================================
+
+fprintf('=====================================================================\n');
+fprintf('       PRESENT VALUE TAX MULTIPLIERS (Zubairy 2014 Style)\n');
+fprintf('=====================================================================\n');
+fprintf('\n');
+fprintf('                            Quarter 1   Quarter 4   Quarter 12  Quarter 20\n');
+fprintf('-------------------------------------------------------------------------\n');
+fprintf('Consumption Tax (Cut)\n');
+fprintf('  PV(DeltaY)/PV(DeltaT_total)  %8.2f    %8.2f    %8.2f    %8.2f\n', ...
+    mult_tau_c(1), mult_tau_c(2), mult_tau_c(3), mult_tau_c(4));
+fprintf('\n');
+fprintf('Labor Tax (Cut)\n');
+fprintf('  PV(DeltaY)/PV(DeltaT_total)  %8.2f    %8.2f    %8.2f    %8.2f\n', ...
+    mult_tau_l(1), mult_tau_l(2), mult_tau_l(3), mult_tau_l(4));
+fprintf('\n');
+fprintf('Capital Tax (Cut)\n');
+fprintf('  PV(DeltaY)/PV(DeltaT_total)  %8.2f    %8.2f    %8.2f    %8.2f\n', ...
+    mult_tau_k(1), mult_tau_k(2), mult_tau_k(3), mult_tau_k(4));
+fprintf('\n');
+fprintf('Interest Tax (Cut)\n');
+fprintf('  PV(DeltaY)/PV(DeltaT_total)  %8.2f    %8.2f    %8.2f    %8.2f\n', ...
+    mult_tau_i(1), mult_tau_i(2), mult_tau_i(3), mult_tau_i(4));
+fprintf('\n');
+fprintf('Dividend Tax (Cut)\n');
+fprintf('  PV(DeltaY)/PV(DeltaT_total)  %8.2f    %8.2f    %8.2f    %8.2f\n', ...
+    mult_tau_d(1), mult_tau_d(2), mult_tau_d(3), mult_tau_d(4));
+fprintf('\n');
+fprintf('Investment Tax Credit (Increase)\n');
+fprintf('  PV(DeltaY)/PV(DeltaOutlay) %8.2f    %8.2f    %8.2f    %8.2f\n', ...
+    mult_tau_ic(1), mult_tau_ic(2), mult_tau_ic(3), mult_tau_ic(4));
+fprintf('=========================================================================\n');
+fprintf('\n');
+
+% Benchmark comparison
+fprintf('BENCHMARK COMPARISON:\n');
+fprintf('-------------------------------------------------------------------------\n');
+fprintf('Zubairy (2014) estimates:\n');
+fprintf('  Labor Tax:               0.13        0.32        0.68        0.85\n');
+fprintf('  Capital Tax:             0.34        0.43        0.52        0.46\n');
+fprintf('\n');
+fprintf('Mertens & Ravn (2013) estimates:\n');
+fprintf('  Personal Income Tax:     Impact ~2.0, Peak ~2.5 at Q3\n');
+fprintf('  Corporate Income Tax:    Impact ~0.4, Peak ~0.6 at Q4\n');
+fprintf('=========================================================================\n');
+fprintf('\n');
+
+%% =========================================================================
+%% PART 7: FIGURE 1 - TAX CUTS COMPARISON (Main Figure)
+%% =========================================================================
+
+figure('Position', [100 100 1400 900], 'Color', 'w', 'Name', 'Tax Cuts Comparison');
+
+% Colors for different taxes
+colors = struct();
+colors.tc = [0.8 0.2 0.2];   % Red - Consumption tax
+colors.tl = [0.2 0.2 0.8];   % Blue - Labor tax
+colors.tk = [0.2 0.7 0.2];   % Green - Capital tax
+colors.ti = [0.8 0.5 0.0];   % Orange - Interest tax
+colors.td = [0.5 0.0 0.8];   % Purple - Dividend tax
+colors.tic = [0.0 0.7 0.7];  % Cyan - ITC
+
+% Output responses to tax CUTS (flip signs except ITC)
+subplot(2,3,1);
+plot(quarters, irf_y_tc_p*100, '-', 'Color', colors.tc, 'LineWidth', 2); hold on;
+plot(quarters, irf_y_tl_p*100, '-', 'Color', colors.tl, 'LineWidth', 2);
+plot(quarters, irf_y_tk_p*100, '-', 'Color', colors.tk, 'LineWidth', 2);
+plot(quarters, irf_y_tic_p*100, '-', 'Color', colors.tic, 'LineWidth', 2);
+plot(quarters, zeros(T,1), 'k--', 'LineWidth', 0.5);
+xlabel('Quarters');
+ylabel('Percent');
+title('Output');
+legend('\tau_c cut', '\tau_l cut', '\tau_k cut', 'ITC increase', 'Location', 'best', 'FontSize', 8);
+xlim([0 T-1]);
+grid on;
+
+% Consumption responses
+subplot(2,3,2);
+plot(quarters, irf_c_tc_p*100, '-', 'Color', colors.tc, 'LineWidth', 2); hold on;
+plot(quarters, irf_c_tl_p*100, '-', 'Color', colors.tl, 'LineWidth', 2);
+plot(quarters, irf_c_tk_p*100, '-', 'Color', colors.tk, 'LineWidth', 2);
+plot(quarters, irf_c_tic_p*100, '-', 'Color', colors.tic, 'LineWidth', 2);
+plot(quarters, zeros(T,1), 'k--', 'LineWidth', 0.5);
+xlabel('Quarters');
+ylabel('Percent');
+title('Consumption');
+xlim([0 T-1]);
+grid on;
+
+% Investment responses
+subplot(2,3,3);
+plot(quarters, irf_i_tc_p*100, '-', 'Color', colors.tc, 'LineWidth', 2); hold on;
+plot(quarters, irf_i_tl_p*100, '-', 'Color', colors.tl, 'LineWidth', 2);
+plot(quarters, irf_i_tk_p*100, '-', 'Color', colors.tk, 'LineWidth', 2);
+plot(quarters, irf_i_tic_p*100, '-', 'Color', colors.tic, 'LineWidth', 2);
+plot(quarters, zeros(T,1), 'k--', 'LineWidth', 0.5);
+xlabel('Quarters');
+ylabel('Percent');
+title('Investment');
+xlim([0 T-1]);
+grid on;
+
+% Hours responses
+subplot(2,3,4);
+plot(quarters, irf_l_tc_p*100, '-', 'Color', colors.tc, 'LineWidth', 2); hold on;
+plot(quarters, irf_l_tl_p*100, '-', 'Color', colors.tl, 'LineWidth', 2);
+plot(quarters, irf_l_tk_p*100, '-', 'Color', colors.tk, 'LineWidth', 2);
+plot(quarters, irf_l_tic_p*100, '-', 'Color', colors.tic, 'LineWidth', 2);
+plot(quarters, zeros(T,1), 'k--', 'LineWidth', 0.5);
+xlabel('Quarters');
+ylabel('Percent');
+title('Hours');
+xlim([0 T-1]);
+grid on;
+
+% Interest and Dividend tax effects on output
+subplot(2,3,5);
+plot(quarters, irf_y_ti_p*100, '-', 'Color', colors.ti, 'LineWidth', 2); hold on;
+plot(quarters, irf_y_td_p*100, '-', 'Color', colors.td, 'LineWidth', 2);
+plot(quarters, zeros(T,1), 'k--', 'LineWidth', 0.5);
+xlabel('Quarters');
+ylabel('Percent');
+title('Output: Interest & Dividend Tax Cuts');
+legend('\tau_i cut', '\tau_d cut', 'Location', 'best', 'FontSize', 9);
+xlim([0 T-1]);
+grid on;
+
+% Tax rate paths
+subplot(2,3,6);
+plot(quarters, irf_tc_tc_p*100, '-', 'Color', colors.tc, 'LineWidth', 2); hold on;
+plot(quarters, irf_tl_tl_p*100, '-', 'Color', colors.tl, 'LineWidth', 2);
+plot(quarters, irf_tk_tk_p*100, '-', 'Color', colors.tk, 'LineWidth', 2);
+plot(quarters, zeros(T,1), 'k--', 'LineWidth', 0.5);
+xlabel('Quarters');
+ylabel('Percentage Points');
+title('Tax Rate Paths (tax cuts, raw shock size)');
+legend('\tau_c', '\tau_l', '\tau_k', 'Location', 'best', 'FontSize', 9);
+xlim([0 T-1]);
+grid on;
+
+sgtitle('Impulse Responses to Tax Policy Shocks', 'FontSize', 14, 'FontWeight', 'bold');
+saveas(gcf, 'IRF_tax_comparison.png');
+saveas(gcf, 'IRF_tax_comparison.eps', 'epsc');
+
+%% =========================================================================
+%% PART 8: FIGURE 2 - CONSUMPTION TAX FOCUS (Key Result)
+%% =========================================================================
+
+figure('Position', [100 100 1000 700], 'Color', 'w', 'Name', 'Consumption Tax Shock');
+
+subplot(2,2,1);
+plot(quarters, irf_y_tc_p*100, 'r-', 'LineWidth', 2.5);
+hold on;
+plot(quarters, zeros(T,1), 'k--', 'LineWidth', 0.5);
+xlabel('Quarters', 'FontSize', 11);
+ylabel('Percent', 'FontSize', 11);
+title('Output', 'FontSize', 12, 'FontWeight', 'bold');
+xlim([0 T-1]);
+grid on;
+box on;
+
+subplot(2,2,2);
+plot(quarters, irf_c_tc_p*100, 'r-', 'LineWidth', 2.5);
+hold on;
+plot(quarters, zeros(T,1), 'k--', 'LineWidth', 0.5);
+xlabel('Quarters', 'FontSize', 11);
+ylabel('Percent', 'FontSize', 11);
+title('Consumption', 'FontSize', 12, 'FontWeight', 'bold');
+xlim([0 T-1]);
+grid on;
+box on;
+
+subplot(2,2,3);
+plot(quarters, irf_i_tc_p*100, 'r-', 'LineWidth', 2.5);
+hold on;
+plot(quarters, zeros(T,1), 'k--', 'LineWidth', 0.5);
+xlabel('Quarters', 'FontSize', 11);
+ylabel('Percent', 'FontSize', 11);
+title('Investment', 'FontSize', 12, 'FontWeight', 'bold');
+xlim([0 T-1]);
+grid on;
+box on;
+
+subplot(2,2,4);
+plot(quarters, irf_l_tc_p*100, 'r-', 'LineWidth', 2.5);
+hold on;
+plot(quarters, zeros(T,1), 'k--', 'LineWidth', 0.5);
+xlabel('Quarters', 'FontSize', 11);
+ylabel('Percent', 'FontSize', 11);
+title('Hours', 'FontSize', 12, 'FontWeight', 'bold');
+xlim([0 T-1]);
+grid on;
+box on;
+
+sgtitle('Impulse Responses to Consumption Tax CUT', 'FontSize', 14, 'FontWeight', 'bold');
+saveas(gcf, 'IRF_consumption_tax.png');
+saveas(gcf, 'IRF_consumption_tax.eps', 'epsc');
+
+%% =========================================================================
+%% PART 9: FIGURE 3 - MULTIPLIERS OVER HORIZON
+%% =========================================================================
+
+figure('Position', [100 100 900 600], 'Color', 'w', 'Name', 'Multipliers Over Horizon');
+
+% Calculate multipliers at each horizon
+all_horizons = 1:T;
+mult_tc_all = zeros(T, 1);
+mult_tl_all = zeros(T, 1);
+mult_tk_all = zeros(T, 1);
+mult_ti_all = zeros(T, 1);
+mult_td_all = zeros(T, 1);
+mult_tic_all = zeros(T, 1);
+
+for h = 1:T
+    discount_factors = (1+R).^(-(0:h-1)');
+    
+    % Consumption tax (cut)
+    sgn = -1;
+    y_path = y_ss + sgn*irf_y_tc(1:h)';
+    rev_ss = Rev_c_ss;
+    rev_path = rev_ss + sgn*irf_rev_c_tc(1:h)';
+    PV_Y = sum(discount_factors .* (y_path - y_ss));
+    PV_Rev = sum(discount_factors .* (rev_path - rev_ss));
+    mult_tc_all(h) = PV_Y / (-PV_Rev);
+    
+    % Labor income tax (cut)
+    sgn = -1;
+    y_path = y_ss + sgn*irf_y_tl(1:h)';
+    p_path = p_ss + sgn*irf_p_tl(1:h)';
+    w_path = w_ss + sgn*irf_w_tl(1:h)';
+    l_path = l_ss + sgn*irf_l_tl(1:h)';
+    tau_path = tau_l_ss + sgn*irf_tl_tl(1:h)';
+    rev_ss = Rev_l_ss;
+    rev_path = rev_ss + sgn*irf_rev_l_tl(1:h)';
+    PV_Y = sum(discount_factors .* (y_path - y_ss));
+    PV_Rev = sum(discount_factors .* (rev_path - rev_ss));
+    mult_tl_all(h) = PV_Y / (-PV_Rev);
+    
+    % Capital income tax (cut)
+    sgn = -1;
+    y_path = y_ss + sgn*irf_y_tk(1:h)';
+    rk_path = r_k_ss + sgn*irf_rk_tk(1:h)';
+    v_path  = v_ss  + sgn*irf_v_tk(1:h)';
+    k_path  = k_ss  + sgn*irf_k_tk(1:h)';
+    ktau_path = k_tau_ss + sgn*irf_ktau_tk(1:h)';
+    i_path  = i_ss  + sgn*irf_i_tk(1:h)';
+    tau_path = tau_k_ss + sgn*irf_tk_tk(1:h)';
+    rev_ss = Rev_k_ss;
+    rev_path = rev_ss + sgn*irf_rev_k_tk(1:h)';
+    PV_Y = sum(discount_factors .* (y_path - y_ss));
+    PV_Rev = sum(discount_factors .* (rev_path - rev_ss));
+    mult_tk_all(h) = PV_Y / (-PV_Rev);
+    
+    % Interest income tax (cut)
+    sgn = -1;
+    y_path = y_ss + sgn*irf_y_ti(1:h)';
+    rev_ss = Rev_i_ss;
+    rev_path = rev_ss + sgn*irf_rev_i_ti(1:h)';
+    PV_Y = sum(discount_factors .* (y_path - y_ss));
+    PV_Rev = sum(discount_factors .* (rev_path - rev_ss));
+    mult_ti_all(h) = PV_Y / (-PV_Rev);
+
+    % Dividend tax (cut)
+    sgn = -1;
+    y_path = y_ss + sgn*irf_y_td(1:h)';
+    rev_ss = Rev_d_ss;
+    rev_path = rev_ss + sgn*irf_rev_d_td(1:h)';
+    PV_Y = sum(discount_factors .* (y_path - y_ss));
+    PV_Rev = sum(discount_factors .* (rev_path - rev_ss));
+    mult_td_all(h) = PV_Y / (-PV_Rev);
+
+    % ITC (increase)
+    sgn = 1;
+    y_path = y_ss + sgn*irf_y_tic(1:h)';
+    i_path = i_ss + sgn*irf_i_tic(1:h)';
+    tau_path = tau_ic_ss + sgn*irf_tic_tic(1:h)';
+    spend_ss = Spend_ic_ss;
+    spend_path = spend_ss + sgn*irf_spend_ic_tic(1:h)';
+    PV_Y = sum(discount_factors .* (y_path - y_ss));
+    PV_Spend = sum(discount_factors .* (spend_path - spend_ss));
+    mult_tic_all(h) = PV_Y / PV_Spend;
+end
+
+plot(all_horizons, mult_tc_all, '-', 'Color', colors.tc, 'LineWidth', 2.5); hold on;
+plot(all_horizons, mult_tl_all, '-', 'Color', colors.tl, 'LineWidth', 2);
+plot(all_horizons, mult_tk_all, '-', 'Color', colors.tk, 'LineWidth', 2);
+plot(all_horizons, mult_ti_all, '-', 'Color', colors.ti, 'LineWidth', 2);
+plot(all_horizons, mult_td_all, '-', 'Color', colors.td, 'LineWidth', 2);
+plot(all_horizons, mult_tic_all, '-', 'Color', colors.tic, 'LineWidth', 2);
+plot(all_horizons, ones(T,1), 'k--', 'LineWidth', 0.5);
+
+xlabel('Horizon (Quarters)', 'FontSize', 12);
+ylabel('Present Value Multiplier', 'FontSize', 12);
+title('Tax Multipliers by Horizon', 'FontSize', 14, 'FontWeight', 'bold');
+legend('Cons. Tax Cut', 'Labor Tax Cut', 'Capital Tax Cut', 'Interest Tax Cut', 'Dividend Tax Cut', 'ITC Increase', ...
+    'Location', 'best', 'FontSize', 10);
+xlim([1 T]);
+grid on;
+box on;
+
+saveas(gcf, 'multipliers_by_horizon.png');
+saveas(gcf, 'multipliers_by_horizon.eps', 'epsc');
+
+%% =========================================================================
+%% PART 10: SAVE RESULTS
+%% =========================================================================
+
+% Save multiplier table to CSV
+T_mult = table(horizons', mult_tau_c, mult_tau_l, mult_tau_k, ...
+    mult_tau_i, mult_tau_d, mult_tau_ic, ...
+    'VariableNames', {'Horizon_Q', 'ConsTax', 'LaborTax', ...
+    'CapitalTax', 'InterestTax', 'DividendTax', 'InvTaxCredit'});
+writetable(T_mult, 'multiplier_table.csv');
+
+% Save all results to MAT file
+save('fiscal_multiplier_results.mat', ...
+    'irf_*', 'mult_*', 'horizons', 'quarters', '*_ss', 'T_*_base');
+
+fprintf('\n');
+fprintf('Results saved to:\n');
+fprintf('  - multiplier_table.csv\n');
+fprintf('  - fiscal_multiplier_results.mat\n');
+fprintf('  - IRF_tax_comparison.png/eps\n');
+fprintf('  - IRF_consumption_tax.png/eps\n');
+fprintf('  - multipliers_by_horizon.png/eps\n');
+fprintf('\n');
+fprintf('Done!\n');
+fprintf('================================================================\n');

--- a/Codes/tax_dsge_fiscal_shocks_b.mod
+++ b/Codes/tax_dsge_fiscal_shocks_b.mod
@@ -1,0 +1,409 @@
+// /************ tax_dsge_fiscal_shocks_b.mod **************/
+// /**  This program sets up the model to be solved by Dynare.
+// ***  There are five part to this file:
+// ***  1. The preamble, which initializes variables and parameters.
+// ***  2. Model, which spells out the model (necessary equations).
+// ***  3. Steady State, which gives the steady state values.
+// ***  4. Shocks, which defines the shocks.
+// ***  5. Computation, which specifies solution method and output.
+// ***
+// ***  Throughout, I try to use the notation we use in our
+// ***  write-up of the model.
+// ***/
+
+// /***************************************************************/
+// /* Preamble */
+// /***************************************************************/
+// /* Endogenous Variables (22) */
+// /** Note that there are more variables here than in the paper - this is because it makes the coding easier to define some variables that are functions of others (e.g. marginal cost) **/
+// c = consumption (private)
+// lambda = marginal utility of consumption
+// q = lagrangian multiplier on the law of motion for capital
+// l = labor supply
+// i = investment
+// b = gov't bond holdings
+// v = capital utilization rate
+// k = capital stock
+// k_tau = tax basis of capital stock
+// g = gov't consumption
+// x = gov't transfers
+// d = dividends distributed from intermediate goods producers
+// z = total factor productivity (AR(1) process) ** Note that z here is ln(z) from the paper **
+// y = output
+// p = price level
+// w = wage rate
+// r_k = capital rental rate
+// r = interest rate on gov't bonds
+// lambda_p = price markup (AR(1) process) ** Note that lambda_p here is ln(lambda_p) from the paper **
+// epsilon_b = stochastic time preference (AR(1) process) ** Note that epsilon_b here is ln(epsilon_b) from the paper **
+// p_star = the price chosen by those int goods producers who can change price
+// mc = marginal cost of the intermediate goods producer
+//
+/* Exogenous Variables (3) */
+// e_b = shock to stochastic time preference
+// e_p = shock to price markup
+// e_z = shock to TFP
+//
+/*  Parameters (30) */
+// betta = time preference parameter
+// siggma = coefficient of relative risk aversion for utility function
+// zetta = Frisch elasticity of labor supply??
+// siggma_g = preference parameter for gov't spending (some elasticity)
+// chi_g = scale parameter for preferences for gov't spending
+// rho_b = persistence of shock to time preference
+// gamma = scale paramter in investment adjustment cost function
+// delta_0 = SS depreciation rate
+// delta_1 = coefficient on linear term in depreciation funciton
+// delta_2 = coefficient on quadratic term in depreciation function
+// alfa = capital's share of output
+// lambda_bar_p = average price markup (BETTER NOTATION!!!!)
+// theta = fraction of intermediate goods producers who cannot change price
+// rho_z = persistence of shock to TFP
+// siggma_z = std dev of shocks to TFP
+// siggma_p = std dev of shocks to price markup
+// siggma_b = std dev of shocks to time preference
+//
+// phi_1 = coeff on inflation rate in Taylor rule
+// phi_2 = coeff on output gap in Taylor rule
+// rho_r = coeff on interest rate difference in Taylor rule
+//
+// tau_c = consumption tax
+// tau_i = tax on interest income
+// tau_k = tax on capital income
+// tau_l = tax on labor income
+// tau_d = tax on dividend income
+// tau_ic = investment tax credit
+// e_tau = rate of expensing for tax purposes
+// delta_tau = rate of depreciation for tax purposes
+//
+// gamma_x = percentage of gov't spending going to transfers - make this a parameter to help id x and g separately
+//
+// lbar = SS labor supply (I think we need this to ID model in SS)
+/***************************************************************/
+var p p_star v z epsilon_b lambda_p r r_k w l k k_tau i y d c lambda q g b x mc A_p B_p tau_c tau_i tau_k tau_l tau_d tau_ic rev_c rev_l rev_k rev_i rev_d spend_ic rev_net;
+
+varexo e_b e_p e_z e_tau_c e_tau_i e_tau_k e_tau_l e_tau_d e_tau_ic;
+
+parameters betta siggma zetta siggma_g chi_g rho_b gamma delta_0 delta_1 delta_2 alfa lambda_bar_p theta phi_1 phi_2 rho_r rho_z rho_lambda siggma_z siggma_b siggma_p tau_c_bar tau_i_bar tau_k_bar tau_l_bar tau_d_bar tau_ic_bar e_tau delta_tau gamma_x lbar ybar rbar r_k_bar wbar mc_bar rho_tau_c rho_tau_i rho_tau_k rho_tau_l rho_tau_d rho_tau_ic;
+
+betta = 0.95 ;
+siggma = 2 ;
+zetta = 0.29 ;
+siggma_g = 1.1 ;
+chi_g = 0.5 ;
+rho_b = 0.9 ;
+gamma = 2 ;
+delta_0 = 0.1 ;
+delta_1 = 0.152632 ; //get this from SS, delta_1 = 1/betta-1+delta_0
+delta_2 = 0.01 ;
+alfa = 0.33 ;
+lambda_bar_p = 0.125 ; // For 12.5% markup (middle of range) (matches Basu & Fernald)
+theta = 0.82 ;
+rho_z = 0.7 ;
+rho_lambda = 0 ;
+siggma_z = 0.01 ;
+siggma_p = 0.01 ;
+siggma_b = 0.01 ;
+
+phi_1 = 1.5 ; // NOTE: To satisfy the Taylor principle and restore determinacy, phi_1 has to be >1.
+phi_2 = 0.03 ;
+rho_r = 0.1 ;
+
+// Steady state tax rates
+tau_c_bar = 0.1 ;
+tau_i_bar = 0.2 ;
+tau_k_bar = 0.35 ;
+tau_l_bar = 0.25 ;
+tau_d_bar = 0.15 ;
+tau_ic_bar = 0 ;
+
+// Tax shock persistence parameters (matching Zubairy 2014)
+rho_tau_c = 0.90 ;
+rho_tau_i = 0.90 ;
+rho_tau_k = 0.90 ;
+rho_tau_l = 0.90 ;
+rho_tau_d = 0.90 ;
+rho_tau_ic = 0.90 ;
+
+e_tau = 0 ;
+delta_tau = 0.1 ;
+//0.13 ;
+
+gamma_x = 0.2 ;
+
+lbar = 0.2 ;
+
+
+// Create steady state variables needed for model equations
+
+// Policy rate from household bond Euler 
+rbar = (1-betta)/(betta*(1-tau_i_bar));
+// Steady-state marginal cost pinned by desired markup 
+// If lambda_bar_p is the net markup, gross markup is 1+lambda_bar_p, so mc_bar = 1/(1+lambda_bar_p).
+mc_bar = 1/(1+lambda_bar_p);
+// Rental rate from the model’s q-Euler + investment FOC 
+r_k_bar = (((1/betta)-1+delta_0)/(1-tau_k_bar))*(1-tau_ic_bar -(tau_k_bar*e_tau) - (betta*tau_k_bar*delta_tau*(1-e_tau)));
+// Wage from the Cobb-Douglas marginal cost identity (p=1, z=0 in steady state) 
+wbar = ((mc_bar*(alfa^alfa)*((1-alfa)^(1-alfa)))/(r_k_bar^alfa))^(1/(1-alfa));
+// Capital scale from the cost-minimization ratio (mc cancels in the ratio) 
+kbar = (alfa/(1-alfa))*(wbar/r_k_bar)*lbar;
+// Output from production (z=0, v=1) 
+ybar = (kbar^alfa)*(lbar^(1-alfa));
+
+
+
+/***************************************************************/
+/* Model */
+/***************************************************************/
+// Equations that define the model:
+// 1. HH Budget Constraint -> consumption
+// 2. HH FOC, consumption -> lambda (Marg Util Cons)
+// 3. HH FOC, labor supply -> labor supply
+// 4. HH FOC, capital -> investment
+// 4. HH FOC, investment -> q
+// 5. HH FOC, bond holdings -> demand for gov't bonds
+// 6. HH FOC, capital utilization -> capital utilization
+// 7. Law of motion for capital stock -> capital stock
+// 8. Law of motion for tax basis of capital stock -> tax basis of cap stock
+// 9. Resource constraint -> y
+// 10. Calibration of g/y -> g
+// 11. Gov't budget constraint -> x
+// 12. Taylor Rule for monetary authority -> r
+// NOTE: The policy rule is written in standard inertial form with r on the left-hand side,
+// and uses gross inflation (p/p(-1)). The max(.,0) ZLB-style kink is omitted because it is non-differentiable.
+// 13. Int. goods producer FOC, effective capital demand -> (with market clearning condition) r_k
+// NOTE: Factor demand conditions are written in real terms consistently with the presence of a price level p,
+// and tie the rental rate to marginal cost rather than implicitly assuming mc = 1.
+// 14. Int. goods producer FOC, labor demand -> (with market clearing condition) -> w
+// NOTE: Same rationale as capital demand, labor demand uses mc and the price level p for consistency.
+// 15. Int. goods producr FOCs -> mc (intermediate variable)
+// 16. Int. goods producer FOC, price -> p_star
+// 17. Int. goods producer profit function -> d
+// NOTE: Dividend definition uses the Calvo aggregation logic, separating non-adjusters priced at p(-1)
+// from adjusters priced at p_star, with demand weights implied by the CES aggregator.
+// 18. Calvo pricing rule -> p
+// 19. AR(1) process for TFP -> z
+// 20. Price markup process -> lambda_p
+// 21. AR(1) process for stochastic time preference -> epsilon_b
+// 23-28. AR(1) processes for fiscal policy shocks -> tau_c, tau_l, tau_k, tau_i, tau_d, tau_ic
+/***************************************************************/
+model ;
+
+// 1. HH Budget Constraint (Eq. 1.2)
+c = ((((1+(r*(1-tau_i)))*b(-1))/p) +(((1-tau_l)*w*l)/p) + (((1-tau_k)*r_k*v*k(-1))/p) + (tau_k*delta_tau*k_tau(-1)) + (tau_ic*i) + (tau_k*e_tau*i) + (((1-tau_d)*d)/p) + x - i - (b/p))/(1+tau_c) ;
+
+// 2. HH FOC, consumption (Eq. 1.25)
+lambda = exp(epsilon_b)*(zetta*(c^(zetta*(1-siggma)-1))*((1-l)^((1-zetta)*(1-siggma))))/(1+tau_c) ;
+
+// 3. HH FOC, labor supply (Eq. 1.26)
+exp(epsilon_b)*((1-zetta)*(c^(zetta*(1-siggma)))*((1-l)^(((1-zetta)*(1-siggma))-1))) = (lambda*w*(1-tau_l))/p ;
+
+// 4. HH FOC, capital (Eq. 1.27)
+q = betta*(((lambda(+1)*(1-tau_k)*r_k(+1)*v(+1))/p(+1)) + (q(+1)*(1-delta_0-(delta_1*(v(+1)-1))-((delta_2/2)*((v(+1)-1)^2))))) ;
+
+// 5. HH FOC, investment (Eq. 1.24)
+lambda*(1-tau_ic-(tau_k*e_tau)) = (q*(1-((gamma/2)*(((i/i(-1))-1)^2))-(gamma*((i/i(-1))-1)*(i/i(-1))))) + (betta*((lambda(+1)*tau_k*delta_tau*(1-e_tau)) + (q(+1)*gamma*((i(+1)/i)-1)*((i(+1)/i)^2)))) ;
+
+// 6. HH FOC, bond holdings (Eq. 1.28)
+lambda/p = ((betta*lambda(+1)*(1+(r(+1)*(1-tau_i))))/p(+1)) ;
+
+// 7. HH FOC, capital utilization (Eq. 1.22)
+(lambda*(1-tau_k)*r_k*k(-1))/p = q*(delta_1+(delta_2*(v-1)))*k(-1) ;
+
+// 8. Law of motion for capital stock (Eq. 1.3)
+k = ((1-(delta_0+(delta_1*(v-1))+((delta_2/2)*((v-1)^2))))*k(-1)) + (i*(1-((gamma/2)*((i/i(-1))-1)^2))) ;
+
+// 9. Law of motion for tax basis of capital stock (Eq. 1.4)
+k_tau = ((1-delta_tau)*k_tau(-1)) + (i*(1-e_tau)) ;
+
+// 10. Resource constraint (Eq. 1.46)
+y = c + i + g ;
+
+// 11. Gov't budget constraint (Eq. 1.79)
+g = (1-gamma_x)*((tau_c*c) + ((tau_l*l*w)/p) + (b/p) + (tau_k*r_k*v*k(-1))/p + ((tau_d*d)/p) - (tau_ic*i) - (tau_k*delta_tau*k_tau(-1)) - (tau_k*e_tau*i) - ((b(-1)*(1+(r*(1-tau_i))))/p)) ;
+
+// 12. Calibrate x is a fraction of gov't spending (Eq. 1.80)
+x = (gamma_x)*((tau_c*c) + ((tau_l*l*w)/p) + (b/p) + (tau_k*r_k*v*k(-1))/p + ((tau_d*d)/p) - (tau_ic*i) - (tau_k*delta_tau*k_tau(-1)) - (tau_k*e_tau*i) - ((b(-1)*(1+(r*(1-tau_i))))/p)) ;
+
+// 13. Taylor Rule for monetary authority (Eq. 1.82)
+r = ((1/betta)*((p/p(-1))^phi_1)*((y/ybar)^phi_2)*(((1+r(-1))/(1+rbar))^rho_r)-1)/(1-tau_i) ;
+// Separates monetary policy (Fed sets r based on macro conditions) from tax policy
+// r = ((1/betta)*((p/p(-1))^phi_1)*((y/ybar)^phi_2)*(((1+r(-1))/(1+rbar))^rho_r)-1);
+
+// 14. Int. goods producer FOC, effective capital demand (Eq. 1.64)
+// NOTE: Under stage-1 cost minimization conditional on producing demanded output, factor demands are scaled by real marginal cost mc (Eq. 1.67, used in Eq. 1.68). With effective capital k_tilde = v*k(-1), this implies r_k*k_tilde = alfa*mc*p*y.
+v*k(-1) = (alfa*mc/r_k)*y*p ;
+
+// 15. Int. goods producer FOC, labor demand (Eq. 1.65)
+// NOTE: Same logic as Eq. 14: labor demand satisfies w*l = (1-alfa)*mc*p*y, so l = ((1-alfa)/w)*mc*y*p.
+l = ((1-alfa)/w)*mc*y*p ;
+
+// 16. Int goods producer marginal cost (Eq. T.2.5)
+// NOTE: Real marginal cost implied by Cobb-Douglas technology and factor prices, with productivity exp(z) and the price level p.
+mc = ((w^(1-alfa))*(r_k^alfa))/(p*exp(z)*(alfa^alfa)*((1-alfa)^(1-alfa))) ;
+
+// 17. Int. goods producer optimal reset price under Calvo pricing (paper Eq. (1.75)–(1.76))
+// NOTE: The paper expresses the optimal reset price p_star as a ratio of two infinite discounted sums (a numerator with marginal costs and a denominator with demand/discounting terms).
+// NOTE: We implement those infinite sums in recursive form for Dynare: A_p is the numerator recursion and B_p is the denominator recursion, so p_star is pinned down by their ratio (scaled by the desired markup term (1+lambda_p)).
+// NOTE: When solving the full nonlinear model at order=2, hard-coding a first-order approximation inside the equilibrium conditions can distort second derivatives and make higher-order dynamics unstable. For order>=2, prefer the nonlinear Calvo implementation via the A_p and B_p recursions; keep these approximations only as commented reference.
+A_p = (lambda*mc*y*(p^((1+lambda_p)/lambda_p))) + (betta*theta*A_p(+1));
+B_p = (lambda*y*(p^((1+lambda_p)/lambda_p - 1))) + (betta*theta*B_p(+1));
+p_star = (1+lambda_p)*(A_p/B_p);
+
+// 18. Int. goods producer profit function (Eq. 1.62)
+// d = y - w*l - r_k*v*k(-1);
+// NOTE: Dividend definition uses the Calvo aggregation logic, separating non-adjusters priced at p(-1), from adjusters priced at p_star, with demand weights implied by the CES aggregator. ;
+d = y*((((theta*((p(-1)/p)^((-1*(1+lambda_p))/lambda_p)))*(p(-1)-mc))) + (((1-theta)*((p_star/p)^((-1*(1+lambda_p))/lambda_p)))*(p_star-mc))) ;
+// if mc is real 
+// d = y*((((theta*((p(-1)/p)^((-1*(1+lambda_p))/lambda_p)))*(p(-1)-mc*p))) + (((1-theta)*((p_star/p)^((-1*(1+lambda_p))/lambda_p)))*(p_star-mc*p))) ; 
+
+// 19. Calvo pricing rule (Eq. 1.51)
+p = ((theta*(p(-1)^(-1/lambda_p))) + ((1-theta)*(p_star^(-1/lambda_p))))^(-lambda_p) ;
+
+// 20. AR(1) process for TFP (Eq. 1.61)
+z = (rho_z*z(-1)) + e_z ;
+
+// 21. Price markup process (Eq. 1.34)
+ln(lambda_p) = (rho_lambda*(ln(lambda_p(-1)))) + ((1-rho_lambda)*ln(lambda_bar_p)) + e_p ;
+
+// 22. AR(1) process for stochastic time preference (Eq. 1.33)
+epsilon_b = (rho_b*epsilon_b(-1)) + e_b ;
+
+// 23-28. AR(1) processes for tax rates (fiscal policy shocks)
+tau_c = (rho_tau_c*tau_c(-1)) + ((1-rho_tau_c)*tau_c_bar) + e_tau_c ;
+tau_i = (rho_tau_i*tau_i(-1)) + ((1-rho_tau_i)*tau_i_bar) + e_tau_i ;
+tau_k = (rho_tau_k*tau_k(-1)) + ((1-rho_tau_k)*tau_k_bar) + e_tau_k ;
+tau_l = (rho_tau_l*tau_l(-1)) + ((1-rho_tau_l)*tau_l_bar) + e_tau_l ;
+tau_d = (rho_tau_d*tau_d(-1)) + ((1-rho_tau_d)*tau_d_bar) + e_tau_d ;
+tau_ic = (rho_tau_ic*tau_ic(-1)) + ((1-rho_tau_ic)*tau_ic_bar) + e_tau_ic ;
+
+
+
+// ===== Auxiliary fiscal accounting variables (for multipliers) =====
+rev_c    = tau_c*c ;
+rev_l    = tau_l*w*l/p ;
+rev_k    = tau_k*(r_k*v*k(-1)/p - delta_tau*k_tau(-1) - e_tau*i) ;
+rev_i    = tau_i*r*b(-1)/p ;
+rev_d    = tau_d*d/p ;
+spend_ic = tau_ic*i ;
+rev_net  = rev_c + rev_l + rev_k + rev_i + rev_d - spend_ic ;
+end ;
+
+
+/***************************************************************/
+/* Steady State (symbolic) */
+/***************************************************************/
+
+
+// NOTE: Alternative (not now): The steady state values below are generated from a separate Python steady-state solver that solves the static version of THIS updated model (same equations, same parameters).
+
+initval;
+// 1. Exogenous shocks
+z         = 0;
+epsilon_b = 0;
+lambda_p  = lambda_bar_p;
+
+// 2. Normalizations 
+p         = 1;
+p_star    = 1;
+v         = 1;
+
+// 3. Prices and rates 
+r         = rbar;
+r_k       = r_k_bar;
+w         = wbar;
+l         = lbar;
+mc        = mc_bar;
+
+// 4. Output and capital 
+k         = kbar;
+k_tau     = delta_0 * k * (1 - e_tau) / delta_tau;
+i         = delta_0 * k;
+y         = ybar;
+
+// 5. Dividends (accounting identity guess) 
+d         = y - w * l - r_k * v * k;
+
+// 6. Tax rates at steady state
+tau_c     = tau_c_bar;
+tau_i     = tau_i_bar;
+tau_k     = tau_k_bar;
+tau_l     = tau_l_bar;
+tau_d     = tau_d_bar;
+tau_ic    = tau_ic_bar;
+
+// 7. Government variables (consistent with budget/tax block) 
+g = (tau_c * (y - i) + tau_l * w * l / p + tau_k * r_k * v * k / p + tau_d * d / p - tau_ic * i - tau_k * delta_tau * k_tau - tau_k * e_tau * i) * (1 - gamma_x);
+b = (tau_c * (y - i) + tau_l * w * l / p + tau_k * r_k * v * k / p + tau_d * d / p - tau_ic * i - tau_k * delta_tau * k_tau - tau_k * e_tau * i - g) / (1 + r * (1 - tau_i));
+x = (tau_c * (y - i) + tau_l * w * l / p + b / p + tau_k * r_k * v * k / p + tau_d * d / p - tau_ic * i - tau_k * delta_tau * k_tau - tau_k * e_tau * i - b * (1 + r * (1 - tau_i)) / p) * gamma_x;
+
+// 8. Consumption from resource constraint 
+c = y - i - g;
+
+// 9. Marginal utility (consistent with utility FOC) 
+lambda = zetta * c^(zetta * (1 - siggma) - 1) * (1 - l)^((1 - zetta) * (1 - siggma)) / (1 + tau_c);
+
+// 10. Capital Euler / investment FOC steady-state object 
+q = lambda * (1 - tau_ic - tau_k * e_tau - betta * tau_k * delta_tau * (1 - e_tau));
+
+// 11. Calvo auxiliary objects (steady-state recursion, p=1 so powers drop out) 
+A_p = (lambda * mc * y) / (1 - betta * theta);
+B_p = (lambda * y)      / (1 - betta * theta);
+
+// Fiscal accounting (steady state values)
+rev_c    = tau_c*c ;
+rev_l    = tau_l*w*l/p ;
+rev_k    = tau_k*(r_k*v*k/p - delta_tau*k_tau - e_tau*i) ;
+rev_i    = tau_i*r*b/p ;
+rev_d    = tau_d*d/p ;
+spend_ic = tau_ic*i ;
+rev_net  = rev_c + rev_l + rev_k + rev_i + rev_d - spend_ic ;
+end;
+
+
+resid(1);
+steady;
+check;
+
+
+
+/***************************************************************/
+/* Shocks */
+/***************************************************************/
+// The model has nine shocks:
+// 1. Shock to time preference (value of consumption across periods)
+// 2. Shock to TFP
+// 3. Shock to price markup
+// 4-9. Shocks to tax rates (fiscal policy)
+/***************************************************************/
+shocks;
+var e_b = siggma_b^2 ;
+var e_z = siggma_z^2 ;
+var e_p = siggma_p^2 ;
+// Fiscal shocks - standard deviations set to generate 1% tax rate changes
+var e_tau_c = 0.01^2 ;
+var e_tau_i = 0.01^2 ;
+var e_tau_k = 0.01^2 ;
+var e_tau_l = 0.01^2 ;
+var e_tau_d = 0.01^2 ;
+var e_tau_ic = 0.01^2 ;
+end;
+
+/***************************************************************/
+/* Computation */
+/***************************************************************/
+// Solve the model with second order taylor approximation.
+// Get all of output.
+// Specify seed to can confirm shock working.
+// set_dynare_seed(1); 
+stoch_simul(order=2, pruning, irf=40, nodisplay);
+
+
+
+
+
+
+
+
+
+


### PR DESCRIPTION
Pull Request: Fiscal Shocks Extension to Tax DSGE Model

## Overview

Modifications made to the baseline Tax DSGE model (`tax_dsge_new.mod`) to enable analysis of **fiscal multipliers** for various tax instruments. The extended model is in `tax_dsge_fiscal_shocks_b.mod`.

We transform tax rates from fixed parameters into **endogenous variables** that follow AR(1) stochastic processes, allowing us to compute impulse responses and present-value multipliers comparable to Mertens & Ravn (2013) and Zubairy (2014).

---

## What Changed

### 1. Tax Rates: Parameters → Endogenous Variables

**Before (baseline model):**
- Tax rates (`tau_c`, `tau_l`, `tau_k`, `tau_i`, `tau_d`, `tau_ic`) were fixed parameters
- No fiscal policy shocks

**After (fiscal shocks model):**
- Tax rates are now **endogenous variables** (28 total = 22 original + 6 tax rates)
- Each tax rate follows an AR(1) process with its own shock

### 2. New Equations Added (Equations 25-30)

Six AR(1) processes for tax rate dynamics:

```dynare
tau_c  = rho_tau_c*tau_c(-1)  + (1-rho_tau_c)*tau_c_bar  + e_tau_c ;
tau_l  = rho_tau_l*tau_l(-1)  + (1-rho_tau_l)*tau_l_bar  + e_tau_l ;
tau_k  = rho_tau_k*tau_k(-1)  + (1-rho_tau_k)*tau_k_bar  + e_tau_k ;
tau_i  = rho_tau_i*tau_i(-1)  + (1-rho_tau_i)*tau_i_bar  + e_tau_i ;
tau_d  = rho_tau_d*tau_d(-1)  + (1-rho_tau_d)*tau_d_bar  + e_tau_d ;
tau_ic = rho_tau_ic*tau_ic(-1) + (1-rho_tau_ic)*tau_ic_bar + e_tau_ic ;
```

Auxiliary fiscal accounting variables (for multipliers):
```dynare
rev_c    = tau_c*c ;
rev_l    = tau_l*w*l/p ;
rev_k    = tau_k*(r_k*v*k(-1)/p - delta_tau*k_tau(-1) - e_tau*i) ;
rev_i    = tau_i*r*b(-1)/p ;
rev_d    = tau_d*d/p ;
spend_ic = tau_ic*i ;
rev_net  = rev_c + rev_l + rev_k + rev_i + rev_d - spend_ic ;
```

### 3. New Shocks Added

| Shock | Description | Sign Convention |
|-------|-------------|-----------------|
| `e_tau_c` | Consumption tax shock | + = tax increase |
| `e_tau_l` | Labor income tax shock | + = tax increase |
| `e_tau_k` | Capital income tax shock | + = tax increase |
| `e_tau_i` | Interest income tax shock | + = tax increase |
| `e_tau_d` | Dividend tax shock | + = tax increase |
| `e_tau_ic` | Investment tax credit shock | + = ITC increase (subsidy) |

### 4. New Parameters Added

**Persistence parameters (based on Zubairy 2014):**
- `rho_tau_c = 0.90`
- `rho_tau_l = 0.90`
- `rho_tau_k = 0.90`
- `rho_tau_i = 0.90`
- `rho_tau_d = 0.90`
- `rho_tau_ic = 0.90`

**Shock standard deviations:**
- All set to `0.01` (1 percentage point shock)

---

## Other Changes or Changes to Consider

### Government Budget Structure (Equations 11-12)

For now we only tax have shocks, no exogenous government spending shock).

#### Units correction carried over into the fiscal-shocks model

In the baseline file `tax_dsge_new.mod`, the capital-income tax term inside the government budget used the nominal capital payment `r_k*v*k(-1)` without deflating by the price level `p`. Elsewhere in the model, the capital-income base is treated in real units (for example, the household budget uses `r_k*v*k(-1)/p`). To keep the government budget internally consistent, the fiscal-shocks file deflates the capital-income tax base by `p`.

Baseline (`tax_dsge_new.mod`, units inconsistent in the capital-income tax term):
```dynare
g = (1-gamma_x)*((tau_c*c) + ((tau_l*l*w)/p) + (b/p) + (tau_k*r_k*v*k(-1)) + ((tau_d*d)/p)
                 - (tau_ic*i) - (tau_k*delta_tau*k_tau(-1)) - (tau_k*e_tau*i)
                 - ((b(-1)*(1+(r*(1-tau_i))))/p)) ;

x = (gamma_x)*((tau_c*c) + ((tau_l*l*w)/p) + (b/p) + (tau_k*r_k*v*k(-1)) + ((tau_d*d)/p)
               - (tau_ic*i) - (tau_k*delta_tau*k_tau(-1)) - (tau_k*e_tau*i)
               - ((b(-1)*(1+(r*(1-tau_i))))/p)) ;
```

Corrected in `tax_dsge_fiscal_shocks_b.mod` (capital-income tax base deflated by `p`):
```dynare
g = (1-gamma_x)*((tau_c*c) + ((tau_l*l*w)/p) + (b/p) + (tau_k*r_k*v*k(-1))/p + ((tau_d*d)/p)
                 - (tau_ic*i) - (tau_k*delta_tau*k_tau(-1)) - (tau_k*e_tau*i)
                 - ((b(-1)*(1+(r*(1-tau_i))))/p)) ;

x = (gamma_x)*((tau_c*c) + ((tau_l*l*w)/p) + (b/p) + (tau_k*r_k*v*k(-1))/p + ((tau_d*d)/p)
               - (tau_ic*i) - (tau_k*delta_tau*k_tau(-1)) - (tau_k*e_tau*i)
               - ((b(-1)*(1+(r*(1-tau_i))))/p)) ;
```


Corresponding changes to Initval (`/p`). Corrected `initval;` terms:
```dynare
g = (tau_c*(y-i) + tau_l*w*l/p + tau_k*r_k*v*k/p + tau_d*d/p - tau_ic*i - tau_k*delta_tau*k_tau - tau_k*e_tau*i) * (1-gamma_x);
b = (tau_c*(y-i) + tau_l*w*l/p + tau_k*r_k*v*k/p + tau_d*d/p - tau_ic*i - tau_k*delta_tau*k_tau - tau_k*e_tau*i - g) / (1 + r*(1-tau_i));
x = (tau_c*(y-i) + tau_l*w*l/p + b/p + tau_k*r_k*v*k/p + tau_d*d/p - tau_ic*i - tau_k*delta_tau*k_tau - tau_k*e_tau*i
     - b*(1 + r*(1-tau_i))/p) * gamma_x;
```

### Closer alignment with Zubairy (2014) tax rules

Zubairy (2014) estimates tax-rate rules with feedback from lagged government debt and lagged output, and allows innovations to different tax instruments to be correlated. The current implementation uses simple AR(1) processes around steady-state rates. A closer match would:

- Add debt and output feedback terms to each tax rule, for example coefficients on lagged debt-to-output and lagged output (or an output gap).
- Allow correlated tax innovations in the `shocks;` block using `corr` statements, for example correlating `e_tau_l` and `e_tau_k`.

These changes mainly affect the propagation of tax shocks and therefore the IRFs and present-value multipliers, the steady state is unchanged once the rules are written in deviation-from-steady-state form.

### Adding an exogenous transfer shock
We have not added a shock to transfer because I'm not sure how to appropraitely add this. Perhaps we need tp consider the effect on process for transfers, government buget constraint, household budget. 

Transfers currently follow from the government budget split between spending and transfers. To study a transfer shock directly, transfers can be given their own stochastic process and treated as a government outlay and a lump-sum household income component. A consistent implementation requires three pieces:

1. **Process for transfers:** specify an AR(1) rule for transfers, for example `x = rho_x*x(-1) + (1-rho_x)*x_bar + e_x` (or a deviation-from-steady-state version).
2. **Government budget:** include transfers as an explicit outlay, and choose a closure for financing the shock (debt adjusts, spending adjusts, distortionary taxes adjust through rules, or a lump-sum tax instrument adjusts).
3. **Household budget:** treat transfers as lump-sum income, which shifts disposable resources and therefore affects consumption and labor supply through the standard wealth effect.

With debt as the short-run residual, a positive transfer shock raises debt on impact. Under debt-stabilizing tax rules (debt feedback), taxes eventually rise, which feeds back into labor, investment, and output dynamics. This makes transfer multipliers sensitive to the chosen fiscal closure and the strength of the debt feedback.

### Dividend definition (compared to the baseline)

Since we define dividend `mc` as a real marginal cost, perhaps it is more theoretically consistent to use :

```dynare
d = y*((((theta*((p(-1)/p)^((-1*(1+lambda_p))/lambda_p)))*(p(-1)-mc*p))) + (((1-theta)*((p_star/p)^((-1*(1+lambda_p))/lambda_p)))*(p_star-mc*p))) ;
d = p*y - w*l - r_k*v*k(-1);
```

In the current implementation, the following two alternatives solve cleanly and the code runs:

```dynare
d = y*((((theta*((p(-1)/p)^((-1*(1+lambda_p))/lambda_p)))*(p(-1)-mc))) + (((1-theta)*((p_star/p)^((-1*(1+lambda_p))/lambda_p)))*(p_star-mc))) ;
// d = y - w*l - r_k*v*k(-1);
```

For now the Calvo-based definition used in the model file is kept unchanged.

I am not sure about this, we should revisit it later. I think for steady state it doesn't matter, since price at ss is 1. 

---


## Validation Results

**IRF Sign Checks (tax INCREASE shocks):**
- `tau_c` ↑ → consumption ↓ (correct)
- `tau_l` ↑ → labor supply ↓ (correct)
- `tau_k` ↑ → investment ↓ (correct)
- `tau_ic` ↑ → investment ↑ (correct - ITC is a subsidy)

---

## Multiplier

### Computing Multipliers

```matlab
plot_irfs_and_multipliers_b
```

This generates:
- IRF plots for all tax shocks (I may have missed some)
- Present-value multiplier table (Zubairy 2014 format)
- Multipliers-by-horizon figure

### Multiplier Interpretation

A present-value multiplier at horizon $k$ (in quarters) is computed as:

- $PV_Y(k) = \sum_{j=0}^{k-1} (1+R)^{-j}\,\Delta Y_{t+j}$
- $PV_F(k) = \sum_{j=0}^{k-1} (1+R)^{-j}\,\Delta F_{t+j}$
- $\text{Multiplier}(k) = \dfrac{PV_Y(k)}{PV_F(k)}$

Here:
- $R$ is the steady-state real discount rate implied by the Euler equation, implemented as $R = 1/\beta - 1$.
- $\Delta Y_{t+j}$ is the level change in output at quarter $t+j$ along the IRF, relative to the no-shock baseline (steady state):
  $\Delta Y_{t+j} \equiv Y_{t+j} - \bar Y$.

- $\Delta F_{t+j}$ is the level change in the fiscal variable used in the denominator, relative to its steady state:
  $\Delta F_{t+j} \equiv F_{t+j} - \bar F$.





Fiscal variable definition used in the denominator

- For tax-rate shocks, $F_t$ is **total tax revenue**, so $\Delta F_{t+j}$ is the change in total tax revenues: $F_t \equiv T_t = \text{rev\_total}_t = \text{rev\_c}_t + \text{rev\_l}_t + \text{rev\_k}_t + \text{rev\_i}_t + \text{rev\_d}_t$.

- For the ITC shock, the fiscal variable is the ITC outlay:
  spend_ic

The auxiliary fiscal-flow variables are defined inside the Dynare model as:
```dynare
rev_c    = tau_c*c ;
rev_l    = tau_l*w*l/p ;
rev_k    = tau_k*(r_k*v*k(-1)/p - delta_tau*k_tau(-1) - e_tau*i) ;
rev_i    = tau_i*r*b(-1)/p ;
rev_d    = tau_d*d/p ;
spend_ic = tau_ic*i ;
rev_net  = rev_c + rev_l + rev_k + rev_i + rev_d - spend_ic ;
```

### Implementation details in `plot_irfs_and_multipliers_b.m`

Takes DSGE model results from Dynare and calculates fiscal multipliers. Makes different tax policies comparable by normalizing them to the same initial size.

---
#### Step 1: Grab the IRFs from Dynare

For each shock (e.g., `e_tau_c`, `e_tau_l`, ..., `e_tau_ic`), read the impulse responses from `oo_.irfs`.

For tax shocks, the denominator comes from revenue helper variables: `rev_c`, `rev_l`, `rev_k`, `rev_i`, `rev_d`.  
For ITC shock, the denominator is `spend_ic`.

---

#### Step 2: Build Total Tax Revenue IRFs

For each tax shock, sum up all revenue components:

```
irf_rev_total_* = irf_rev_c_* + irf_rev_l_* + irf_rev_k_* + irf_rev_i_* + irf_rev_d_*
```

This `irf_rev_total_*` is what later shows up in the PV denominator for the tax multipliers.

---

#### Step 3: Calculate Steady-State Benchmarks

 $T^{\cdot}_{ss}$ objects are the steady-state tax bases in real units. They're used to back out steady-state revenues like $\text{Rev}^{c}_{ss}=\tau^{c}_{ss}T^{c}_{ss}$, which then lets the script define "1% of steady-state total tax revenue" for the normalization target.

**Tax bases (steady state):**
- $T^{c}_{ss} = c_{ss}$
- $T^{l}_{ss} = \frac{w_{ss} \, l_{ss}}{p_{ss}}$
- $T^{k}_{ss} = \frac{r_{k,ss} \, v_{ss} \, k_{ss}}{p_{ss}} - \delta_{\tau} k_{\tau,ss} - e_{\tau} i_{ss}$
  - $\frac{r_{k,ss} v_{ss} k_{ss}}{p_{ss}}$ is real capital income (rental rate times effective utilized capital)
  - The $- \delta_{\tau} k_{\tau,ss}$ and $- e_{\tau} i_{ss}$ terms are modeling deductions/allowances (depreciation-type and expensing-type items). So the base is taxable capital income, not gross capital income.
- $T^{i}_{ss} = \frac{r_{ss} \, b_{ss}}{p_{ss}}$
- $T^{d}_{ss} = \frac{d_{ss}}{p_{ss}}$
- $T^{ic}_{ss} = i_{ss}$

**Steady-state fiscal flows:**
- Each revenue type = (tax rate) × (tax base)
  - $\text{Rev}^{c}_{ss} = \tau^{c}_{ss} T^{c}_{ss}$, ..., $\text{Rev}^{d}_{ss} = \tau^{d}_{ss} T^{d}_{ss}$
  - $\text{Spend}^{ic}_{ss} = \tau^{ic}_{ss} T^{ic}_{ss}$
- $\text{Rev}^{total}_{ss} = \text{Rev}^{c}_{ss} + \text{Rev}^{l}_{ss} + \text{Rev}^{k}_{ss} + \text{Rev}^{i}_{ss} + \text{Rev}^{d}_{ss}$

These set the normalization targets. The actual PV denominator comes from Dynare IRFs.

We could also just use the revenue variables from the model directly. For example, take `rev_c_ss`, `rev_l_ss`, `rev_k_ss`, `rev_i_ss`, `rev_d_ss` from `oo_.steady_state` and set `Rev_total_ss = rev_c_ss + rev_l_ss + rev_k_ss + rev_i_ss + rev_d_ss`. 


---

#### Step 4: Normalize Shocks to Same Impact Size

**The Problem:** A "1% shock" to different tax rates means different things in dollar terms. A 1% cut to the labor tax might reduce revenue by $10 billion, while a 1% cut to the dividend tax might reduce revenue by $1 billion. How do we compare these?

**The Solution:** Scale each shock so they all have the **same economic impact on day one**.

**For tax cuts:**
- Target: Each tax cut reduces revenue by **1% of total steady-state revenue** on impact
- The script looks at the raw IRF and asks: "This shock produced a revenue drop of $X on impact. What scale factor do I need to multiply by to make it exactly 1% of steady-state total revenue?"

**For the ITC (investment tax credit):**
- Target: The ITC increase raises spending by **1% of steady-state GDP** on impact
- Similar scaling logic

**The Math:**
```matlab
% For consumption tax cut example:
target = 0.01 × Total_Revenue_SS              % Want 1% of steady-state revenue
actual_impact = irf_rev_total_tc(1)           % What the raw shock actually did
scale_factor = target / actual_impact         % How much to multiply by

% Apply the scale factor to ALL variables in this shock
irf_y_tc_normalized = -scale_factor × irf_y_tc
irf_rev_total_tc_normalized = -scale_factor × irf_rev_total_tc
```

Every tax instrument now represents the same size initial fiscal impulse, making them directly comparable.

**Example**

Set targets:
- Tax shocks: `target_tax_rev_drop = 0.01 * Rev_total_ss` (1% of steady-state total revenue)
- ITC shock: `target_itc_outlay = 0.01 * y_ss` (1% of steady-state GDP)

Calculate scale factors using impact (period 1) responses:
For tax cuts (e.g., consumption tax):
```matlab
scale_tc = target_tax_rev_drop / irf_rev_total_tc(1)
irf_y_tc_n = -scale_tc * irf_y_tc
irf_rev_total_tc_n = -scale_tc * irf_rev_total_tc
```

The minus sign enforces the "tax cut" - impact revenue change is negative and equals 1% of steady-state total revenue.

For ITC:
```matlab
scale_tic = target_itc_outlay / irf_spend_ic_tic(1)
irf_y_tic_n = scale_tic * irf_y_tic
irf_spend_ic_tic_n = scale_tic * irf_spend_ic_tic
```

No sign flip - just scales the outlay increase to 1% of GDP.

After normalization:
- Taxes: revenue drop of 1% of steady-state total revenue on impact
- ITC: outlay increase of 1% of steady-state GDP on impact


#### Step 5: Compute PV Multipliers

**"Per $1 of revenue lost, how much GDP do we gain over the next k quarters?"**
- Discount factors: `(1+R)^(-t)` weight future values less
    ```matlab
    discount_factors = (1+R).^(-(0:k-1)')
    ```
**The Calculation (for k-quarter horizon):**

1. **Create paths** (steady state + normalized IRF):
   ```
   GDP_path = GDP_SS + normalized_GDP_irf[quarters 0 to k]
   Revenue_path = Revenue_SS + normalized_revenue_irf[quarters 0 to k]
   ```
   ```matlab
   y_path = y_ss + irf_y_tc_n(1:k)'
   rev_path = Rev_total_ss + irf_rev_total_tc_n(1:k)'
   ```

2. **Calculate changes from steady state**:
   ```
   ΔY = GDP_path - GDP_SS  (this equals the normalized IRF)
   ΔRev = Revenue_path - Revenue_SS
   ``` 
   ```matlab
   PV_Y = sum(discount_factors .* (y_path - y_ss))
   PV_Rev = sum(discount_factors .* (rev_path - Rev_total_ss))
   ```
 

3. **Apply discount factors and sum**: 
PV sums are computed from level changes
   ```
   PV_Y = Σ (discount_factor[t] × ΔY[t])
   PV_Rev = Σ (discount_factor[t] × ΔRev[t])
   ```
   ```matlab
    PV_Y = sum(discount_factors .* (y_path - y_ss))
    PV_Rev = sum(discount_factors .* (rev_path - Rev_total_ss))
    ```

4. **Calculate the multiplier**:
Reported tax multipliers are “per $1 of PV revenue reduction,” so the script divides by the negative of the PV revenue change:
   ```
   Multiplier = PV_Y / (-PV_Rev)
   ```
   ```matlab
   mult_tau_c(k) = PV_Y / (-PV_Rev)
   ```

#### Step 6: Report Across Multiple Horizons
